### PR TITLE
Support timeout for commands

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,7 +15,7 @@ pull_request_rules:
       - label=ready-to-merge
     actions:
       merge:
-        method: squash
+        method: merge
         commit_message_template: |
           {{ title }} (#{{ number }})
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -14,9 +14,8 @@ pull_request_rules:
       - label!=do-not-merge
       - label=ready-to-merge
     actions:
-      queue:
+      merge:
         method: merge
-        name: default
         commit_message_template: |
           {{ title }} (#{{ number }})
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,7 +15,7 @@ pull_request_rules:
       - label=ready-to-merge
     actions:
       merge:
-        method: merge
+        method: squash
         commit_message_template: |
           {{ title }} (#{{ number }})
 

--- a/tooling/go.mod
+++ b/tooling/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/karrick/godirwalk v1.16.1 // indirect
 	golang.org/x/mod v0.5.1 // indirect
-	golang.org/x/sys v0.0.0-20211213223007-03aa0b5f6827 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/tools v0.1.8 // indirect
 	k8s.io/klog/v2 v2.10.0 // indirect
 )

--- a/tooling/go.sum
+++ b/tooling/go.sum
@@ -38,8 +38,9 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211213223007-03aa0b5f6827 h1:A0Qkn7Z/n8zC1xd9LTw17AiKlBRK64tw3ejWQiEqca0=
 golang.org/x/sys v0.0.0-20211213223007-03aa0b5f6827/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package zfs
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -10,9 +11,36 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
 
 	"github.com/google/uuid"
 )
+
+// Runner specifies the parameters used when executing ZFS commands.
+type Runner struct {
+	// Timeout specifies how long to wait before sending a SIGTERM signal to the running process.
+	Timeout time.Duration
+
+	// Grace specifies the time waited after signaling the running process with SIGTERM before it is forcefully
+	// killed with SIGKILL.
+	Grace time.Duration
+}
+
+var defaultRunner atomic.Value
+
+func init() {
+	defaultRunner.Store(&Runner{})
+}
+
+func Default() *Runner {
+	return defaultRunner.Load().(*Runner) //nolint: forcetypeassert // Impossible for it to be anything else.
+}
+
+func SetRunner(runner *Runner) {
+	defaultRunner.Store(runner)
+}
 
 type command struct {
 	Command string
@@ -21,7 +49,19 @@ type command struct {
 }
 
 func (c *command) Run(arg ...string) ([][]string, error) {
-	cmd := exec.Command(c.Command, arg...)
+	var cmd *exec.Cmd
+	if Default().Timeout == 0 {
+		cmd = exec.Command(c.Command, arg...)
+	} else {
+		ctx, cancel := context.WithTimeout(context.Background(), Default().Timeout)
+		defer cancel()
+
+		cmd = exec.CommandContext(ctx, c.Command, arg...)
+		cmd.Cancel = func() error {
+			return cmd.Process.Signal(syscall.SIGTERM)
+		}
+		cmd.WaitDelay = Default().Grace
+	}
 
 	var stdout, stderr bytes.Buffer
 

--- a/zfs_test.go
+++ b/zfs_test.go
@@ -38,7 +38,7 @@ func TestDatasetGetProperty(t *testing.T) {
 
 	prop, err = ds.GetProperty("compression")
 	ok(t, err)
-	equals(t, "off", prop)
+	equals(t, "on", prop)
 
 	// creation should be a time stamp with spaces in it
 	prop, err = ds.GetProperty("creation")


### PR DESCRIPTION
Commands can now be stopped after the specified timeout. The default behaviour of no timeouts is kept the same. Users wanting to opt into this feature must set a new DefaultRunner with properly set values.

Related to #70.